### PR TITLE
[ALLI-19524]: Criteo Version Bump from `2024-07` to `2025-10`

### DIFF
--- a/lib/criteo_api.js
+++ b/lib/criteo_api.js
@@ -15,7 +15,7 @@ const sha512 = require('js-sha512').sha512;
  */
 class Criteo_API_Client extends API_Client {
 
-    constructor(id, secret, timeout, host = 'api.criteo.com', endpoint = '', version = '2024-07') {
+    constructor(id, secret, timeout, host = 'api.criteo.com', endpoint = '', version = '2025-10') {
         super(host, timeout);
         this.endpoint = endpoint;
         this.version = version;


### PR DESCRIPTION
## Description
This PR resolves [ALLI-19524](https://agencypmg.atlassian.net/browse/ALLI-19524) - Upgrading the Criteo API version from `2024-07` to `2025-10`. 

## Validation

No breaking changes according to the [changelog](https://developers.criteo.com/marketing-solutions/changelog/version-202510-release-notes) for the endpoints or auth methods we use. 

1. We use the `Client Credentials` OAuth method but they're  rate limiting the `Authorization Code` method. 
2. Have also verified that there are no breaking changes when upgrading from `2024-07` to the API versions before `2025-10`. 
3. The only notable thing is that `2025-07` supports a [real time statistics endpoint](https://developers.criteo.com/marketing-solutions/v2025.04/changelog/version-202507-release-notes) but it says Page Not Found when I click on the link. 
<img width="1050" height="581" alt="image" src="https://github.com/user-attachments/assets/0cc540a2-c520-43a8-b434-1e138bdbb52d" />

[ALLI-19524]: https://agencypmg.atlassian.net/browse/ALLI-19524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ